### PR TITLE
Use string replace to convert '_' to '-', rather than dict lookup.

### DIFF
--- a/PyZenity.py
+++ b/PyZenity.py
@@ -63,20 +63,12 @@ def run_zenity(type, *args):
     return Popen([zen_exec, type] + list(args), stdin=PIPE, stdout=PIPE, stderr=PIPE)
 
 
-# This is a dictionary of optional parameters that would create 
-# syntax errors in python if they were passed in as kwargs.
-kw_subst = {
-    'window_icon': 'window-icon',
-    'ok_label': 'ok-label',
-    'cancel_label': 'cancel-label'
-}
-
 def kwargs_helper(kwargs):
     """This function preprocesses the kwargs dictionary to sanitize it."""
 
     args = []
     for param, value in kwargs.items():
-        param = kw_subst.get(param, param)
+        param = param.replace('_', '-')
         args.append((param, value))
     return args
 


### PR DESCRIPTION
A dict lookup was used for converting kwargs params containing underscores to the form expected by Zenity, using hyphens. This caused problems with options that were omitted from the dict. Rather than having to update the dict to keep in step with Zenity, I have removed the lookup and used string replacement to perform the conversion. This takes care of all such options, even the ones  I don't know about, or new ones added in the future.